### PR TITLE
Add upcomming trimesters to admin dashboard with request spec

### DIFF
--- a/app/controllers/admin_dashboard_controller.rb
+++ b/app/controllers/admin_dashboard_controller.rb
@@ -1,0 +1,17 @@
+class AdminDashboardController < ApplicationController
+  
+  def index
+    today = Date.today
+
+    @current_trimester = Trimester
+      .where("start_date <= ?", today)
+      .where("end_date >= ?", today)
+      .first
+
+    @upcoming_trimester = Trimester
+      .where("start_date > ?", today)
+      .where("start_date < ?", today + 6.months)
+      .order(:start_date)
+      .first
+  end
+end

--- a/app/controllers/admin_dashboard_controller.rb
+++ b/app/controllers/admin_dashboard_controller.rb
@@ -1,14 +1,16 @@
 class AdminDashboardController < ApplicationController
   
   def index
-    today = Date.today
+    today = Time.zone.today
 
     @current_trimester = Trimester
+      .includes(courses: :coding_class)
       .where("start_date <= ?", today)
       .where("end_date >= ?", today)
       .first
 
     @upcoming_trimester = Trimester
+      .includes(courses: :coding_class)
       .where("start_date > ?", today)
       .where("start_date < ?", today + 6.months)
       .order(:start_date)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,6 +8,13 @@ class CoursesController < ApplicationController
 
   # GET /courses/1 or /courses/1.json
   def show
+    @course = Course.find(params[:id])
+    
+    t = @course.trimester
+    today = Date.today
+    is_current = t.start_date <= today && t.end_date >= today
+
+    @students = is_current ? @course.students : []
   end
 
   # GET /courses/new
@@ -55,5 +62,11 @@ class CoursesController < ApplicationController
     # Only allow a list of trusted parameters through.
     def course_params
       params.expect(course: [ :coding_class_id, :trimester_id, :max_enrollment ])
+    end
+
+    def current_course?(course)
+      t = course.trimester
+      today = Date.today
+      t.start_date <= today && t.end_date >= today
     end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,4 +1,5 @@
 class CoursesController < ApplicationController
+  # Ensuring @course is loaded
   before_action :set_course, only: %i[ show edit update destroy ]
 
   # GET /courses or /courses.json
@@ -6,15 +7,10 @@ class CoursesController < ApplicationController
     @courses = Course.all
   end
 
-  # GET /courses/1 or /courses/1.json
+  # find the course by id, if in the current trimester load students
   def show
     @course = Course.find(params[:id])
-    
-    t = @course.trimester
-    today = Date.today
-    is_current = t.start_date <= today && t.end_date >= today
-
-    @students = is_current ? @course.students : []
+    @students = current_course?(@course) ? @course.students : []
   end
 
   # GET /courses/new
@@ -64,6 +60,8 @@ class CoursesController < ApplicationController
       params.expect(course: [ :coding_class_id, :trimester_id, :max_enrollment ])
     end
 
+    # checks if a course is part of the current trimester
+    # returns true if today's date fall between the start and end date
     def current_course?(course)
       t = course.trimester
       today = Date.today

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,7 +1,8 @@
 class Course < ApplicationRecord
   belongs_to :coding_class
   belongs_to :trimester
-  has_many :enrollments
+  has_many :enrollments, dependent: :destroy
+  has_many :students, through: :enrollments
 
   delegate :title, to: :coding_class
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,7 +1,5 @@
 class Student < ApplicationRecord
-  has_many :enrollments
-  # I'm going to add this here for my own reference. 
-  # this says from student to all the courses they're enrolled in
+  has_many :enrollments, dependent: :destroy
   has_many :courses, through: :enrollments
 
   validates :first_name, :last_name, :email, presence: true

--- a/app/views/admin_dashboard/index.html.erb
+++ b/app/views/admin_dashboard/index.html.erb
@@ -1,1 +1,19 @@
-<h1>Dashboard</h1>
+<h1>Admin Dashboard</h1>
+
+<% if @current_trimester %>
+  <h2><%= "#{@current_trimester.term} - #{@current_trimester.year}" %></h2>
+  <ul>
+    <% @current_trimester.courses.each do |course| %>
+      <li><%= link_to course.coding_class.title, course_path(course) %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @upcoming_trimester %>
+  <h2><%= "#{@upcoming_trimester.term} - #{@upcoming_trimester.year}" %></h2>
+  <ul>
+    <% @upcoming_trimester.courses.each do |course| %>
+      <li><%= link_to course.coding_class.title, course_path(course) %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,10 +1,14 @@
-<p style="color: green"><%= notice %></p>
 
-<%= render @course %>
+<h1><%= @course.coding_class.title %></h1>
+<p><strong>Trimester: </strong><%= "#{@course.trimester.term} - #{@course.trimester.year}" %></p>
 
-<div>
-  <%= link_to "Edit this course", edit_course_path(@course) %> |
-  <%= link_to "Back to courses", courses_path %>
-
-  <%= button_to "Destroy this course", @course, method: :delete %>
-</div>
+<h2>Enrolled Students</h2>
+<% if @students.any? %>
+  <ul>
+    <% @students.each do |s| %>
+      <li><%= "#{s.first_name} #{s.last_name}" %></li>
+      <% end %>
+  </ul>
+<% else %>
+    <p>No enrolled students yet.</p>
+<% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -10,5 +10,5 @@
       <% end %>
   </ul>
 <% else %>
-    <p>No enrolled students yet.</p>
+    <p>No enrollments to display. (Enrollments are shown only for current courses.)</p>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,8 +22,8 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.cache_store = :null_store
 
-  # Render exception templates for rescuable exceptions and raise for other exceptions.
-  config.action_dispatch.show_exceptions = :rescuable
+  # Render exception templates for rescue able exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,9 @@ Rails.application.routes.draw do
   
   # when GET hits /mentors run MentorController#index
   resources :mentors, only: [:index, :show]
+
+  # when visiting /dashboard call the AdminDashboardController
+  get "/dashboard", to: "admin_dashboard#index"
+
+  resources :courses, only: [:show]
 end

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :request do
+  describe "GET /dashboard" do
+    # Helper for readability
+    let(:today) { Date.today }
+
+    # Current trimester: start <= today <= end
+    let!(:current_trimester) do
+      Trimester.create!(
+        term: "Spring",
+        year: today.year.to_s,
+        start_date: today - 1.day,
+        end_date: today + 2.months,
+        application_deadline: today - 2.weeks
+        )
+    end
+
+    # past trimester: ends before today 
+    let!(:past_trimester) do
+      Trimester.create!(
+        term: "Winter",
+        year: (today.year - 1).to_s,
+        start_date: today - 6.months,
+        end_date: today - 3.months,
+        application_deadline: today - 7.months
+      )
+    end
+
+    # upcoming trimester: starts after today 
+    let!(:upcoming_trimester) do
+      Trimester.create!(
+        term: "Summer",
+        year: today.year.to_s,
+        start_date: today + 1.months,
+        end_date: today + 4.months,
+        application_deadline: today + 2.weeks
+      )
+    end
+
+    # Course titles live on coding classes
+    let!(:cc_intro) { CodingClass.create!(title: "Intro to Programming") }
+    let!(:cc_rails) { CodingClass.create!(title: "Ruby on Rails") }
+    let!(:cc_python) { CodingClass.create!(title: "Python") }
+
+    let!(:current_course_1) { Course.create!(trimester: current_trimester, coding_class: cc_intro) }
+    let!(:current_course_2) { Course.create!(trimester: current_trimester, coding_class: cc_rails) }
+    let!(:upcoming_course) { Course.create!(trimester: upcoming_trimester, coding_class: cc_python) }
+
+    it "returns a 200 ok status" do
+      get "/dashboard"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "Shows the current trimester header and course title" do
+      get "/dashboard"
+      expect(response.body).to include("Spring - #{today.year}")
+      expect(response.body).to include("Intro to Programming")
+      expect(response.body).to include("Ruby on Rails")
+      # Past should not appear
+      expect(response.body).not_to include("Winter - #{today.year - 1}")
+    end
+
+    it "displays the upcoming trimester header and it's course title" do
+      get "/dashboard"
+      expect(response.body).to include("Summer - #{today.year}")
+      expect(response.body).to include("Python")
+    end
+
+    it "displays the upcoming trimester" do
+      today = Date.today
+
+      # a trimester that begins within 6 months should be considered "upcoming"
+      fall = Trimester.create!(
+        term: "Fall",
+        year: today.year.to_s,
+        start_date: today + 2.weeks, 
+        end_date: today + 3.months,
+        application_deadline: today + 1.week
+      )
+
+      get "/dashboard"
+      expect(response.body).to include("#{fall.term} - #{fall.year}")
+    end
+
+  end
+end

--- a/spec/requests/courses_controller_spec.rb
+++ b/spec/requests/courses_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+# look at this later. "Api::V1::Courses" I removed these folders. 
 RSpec.describe "Api::V1::Courses", type: :request, skip: true do
   # Set up current, past and future trimesters and courses for each
   let!(:current_trimester) {

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Courses", type: :request do
+  describe "GET /courses/:id" do
+    let(:today) { Date.today }
+
+    # current trimester
+    let!(:current_trimester) do
+      Trimester.create!(
+        term: "Spring",
+        year: today.year.to_s,
+        start_date: today - 1.day,
+        end_date: today + 2.months,
+        application_deadline: today - 2.weeks
+        )
+    end
+
+    let!(:cc_intro) { CodingClass.create!(title: "Intro to Programming") }
+    let!(:course) { Course.create!(trimester: current_trimester, coding_class: cc_intro) }
+
+    # Students + Enrollments...
+    let!(:student_1) { Student.create!(first_name: "Mechelle", last_name: "Presnell", email: "me@me.com") }
+    let!(:student_2) { Student.create!(first_name: "Bri", last_name: "Malcuit", email: "bri@bri.com") }
+
+    let!(:enroll_1) { Enrollment.create!(course: course, student: student_1) }
+    let!(:enroll_2) { Enrollment.create!(course: course, student: student_2) }
+
+    it "shows the enrolled students for the current course" do
+      get course_path(course)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(cc_intro.title)
+      expect(response.body).to include("Mechelle Presnell")
+      expect(response.body).to include("Bri Malcuit")
+    end
+  end
+end


### PR DESCRIPTION
Extends the admin dashboard to show both the current and upcoming trimesters and implements a course show page that lists enrolled students.